### PR TITLE
Add create table functionality

### DIFF
--- a/packages/sq/src/Create.ts
+++ b/packages/sq/src/Create.ts
@@ -1,0 +1,58 @@
+import squel from 'squel';
+
+class CreateTableBlock extends squel.cls.Block {
+  private _name!: string;
+
+  table(name: string) {
+    this._name = name;
+  }
+
+  _toParamString() {
+    return {
+      text: this._name,
+      values: [],
+    };
+  }
+}
+
+class CreateFieldBlock extends squel.cls.Block {
+  private _fields: {
+    name: string;
+    type: string;
+  }[];
+
+  constructor(options?: squel.QueryBuilderOptions) {
+    super(options);
+    this._fields = [];
+  }
+
+  field(name: string, type: string) {
+    this._fields.push({
+      name: name,
+      type: type,
+    });
+  }
+
+  _toParamString() {
+    let str = this._fields
+      .map(f => {
+        return `${f.name} ${f.type.toUpperCase()}`;
+      })
+      .join(', ');
+
+    return {
+      text: `(${str})`,
+      values: [],
+    };
+  }
+}
+
+export default class Create extends squel.cls.QueryBuilder {
+  constructor(options: squel.QueryBuilderOptions) {
+    super(options, [
+      new squel.cls.StringBlock(options, 'CREATE TABLE'),
+      new CreateTableBlock(options),
+      new CreateFieldBlock(options),
+    ]);
+  }
+}

--- a/packages/sq/src/index.ts
+++ b/packages/sq/src/index.ts
@@ -1,6 +1,22 @@
-import squel, { QueryBuilder, Select, Insert, Update } from 'squel';
+import squel, {
+  Squel,
+  QueryBuilder,
+  QueryBuilderOptions,
+  Select,
+  Insert,
+  Update,
+} from 'squel';
+import Create from './Create';
 
-// Currently, this just re-exports Squel, but in the future,
-// this will be the central place for modifications to squel.
-export default squel;
-export { QueryBuilder, Select, Insert, Update };
+interface SQ extends Squel {
+  create(options?: QueryBuilderOptions): Create;
+}
+
+const sq = squel as SQ;
+
+sq.create = (options: QueryBuilderOptions) => {
+  return new Create(options);
+};
+
+export { QueryBuilder, Select, Insert, Update, Create };
+export default sq;


### PR DESCRIPTION
@Emily 

This adds `create()` to sq so that migrations are able to create tables.