### PR TITLE
Add types for associations and improve pluck

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,0 @@
-# Table of Contents
-
-- [Read Me](../README.md)
-- [Getting Started](introduction/GettingStarted.md)
-- [API Reference](api/README.md)
-  - [createRepository](api/createRepository.md)
-  - [Shema](api/Schema.md)
-  - [Migration](api/Migration.md)
-- [Change Log](../CHANGELOG.md)

--- a/docs/adapters/mysql.md
+++ b/docs/adapters/mysql.md
@@ -4,7 +4,7 @@ title: MySQL Adapter
 sidebar_label: MySQL Adapter
 ---
 
-The MySQL adapter is used to connect to MySQL databases. It uses the `mysql2` module under the hood.
+The MySQL adapter is used to connect to MySQL databases. It uses the `mysql` module under the hood.
 
 ## Connection Pooling
 

--- a/docs/adapters/postgres.md
+++ b/docs/adapters/postgres.md
@@ -16,7 +16,7 @@ npm install @fewer/adapter-postgres
 
 ```ts
 import { createDatabase } from 'fewer';
-import { Adapter } from '@fewer/adapter-postgres';
+import { PostgresAdapter as Adapter } from '@fewer/adapter-postgres';
 
 createDatabase({
   adapter: new Adapter({

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -48,7 +48,7 @@ Open the **`db.ts`** file to configure your database connection:
 
 ```ts
 import { createDatabase } from 'fewer';
-import { Adapter } from '@fewer/adapter-mysql';
+import { MySQLAdapter as Adapter } from '@fewer/adapter-mysql';
 
 export default createDatabase({
   adapter: new Adapter({

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -15,5 +15,5 @@ interface IUsers {
   lastName?: string;
 }
 
-const Users = createRepository<IUsers>('users');
+const Users = createAIUsers>('users');
 ```

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -15,5 +15,5 @@ interface IUsers {
   lastName?: string;
 }
 
-const Users = createAIUsers>('users');
+const Users = createRepository<IUsers>('users');
 ```

--- a/packages/adapter-mysql/README.md
+++ b/packages/adapter-mysql/README.md
@@ -1,0 +1,3 @@
+# `@fewer/adapter-mysql`
+
+> TODO: description

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fewer/adapter-mysql",
   "version": "0.0.5",
-  "description": "> TODO: description",
+  "description": "A Fewer database adapter to connect to MySQL",
   "keywords": [
     "fewer",
     "adapter",

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@fewer/adapter-mysql",
+  "version": "0.0.5",
+  "description": "> TODO: description",
+  "keywords": [
+    "fewer",
+    "adapter",
+    "mysql"
+  ],
+  "author": "Jordan Gensler <jgensler@netflix.com>",
+  "homepage": "https://github.com/fewer/fewer",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fewer/fewer.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/fewer/fewer/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "mysql": "^2.16.0"
+  },
+  "devDependencies": {
+    "@types/mysql": "^2.15.5",
+    "@types/pg": "^7.4.11",
+    "fewer": "^0.0.5"
+  }
+}

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -1,0 +1,34 @@
+import { Adapter as BaseAdapter } from 'fewer';
+import mysql, { Connection, ConnectionConfig } from 'mysql';
+
+export class MySQLAdapter implements BaseAdapter {
+  private connection: Connection;
+
+  constructor(options: ConnectionConfig) {
+    this.connection = mysql.createConnection(options);
+  }
+
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.connection.connect(err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  query(queryString: string, values: any[]) {
+    return new Promise((resolve, reject) => {
+        this.connection.query(queryString, values, (error, results) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(results);
+            }
+        });
+    });
+  }
+}

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -8,8 +8,8 @@ export class MySQLAdapter implements BaseAdapter {
     this.connection = mysql.createConnection(options);
   }
 
-  connect(): Promise<void> {
-    return new Promise((resolve, reject) => {
+  connect() {
+    return new Promise<void>((resolve, reject) => {
       this.connection.connect(err => {
         if (err) {
           reject(err);
@@ -20,15 +20,15 @@ export class MySQLAdapter implements BaseAdapter {
     });
   }
 
-  query(queryString: string, values: any[]) {
-    return new Promise((resolve, reject) => {
-        this.connection.query(queryString, values, (error, results) => {
-            if (error) {
-                reject(error);
-            } else {
-                resolve(results);
-            }
-        });
+  query(queryString: string, values?: any[]) {
+    return new Promise<any[]>((resolve, reject) => {
+      this.connection.query(queryString, values, (error, results) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(results);
+        }
+      });
     });
   }
 }

--- a/packages/adapter-mysql/tsconfig.json
+++ b/packages/adapter-mysql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+      "outDir": "lib"
+    },
+    "include": ["./src"],
+    "references": [{ "path": "../fewer" }]
+  }

--- a/packages/adapter-postgres/package.json
+++ b/packages/adapter-postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fewer/adapter-postgres",
   "version": "0.0.5",
-  "description": "> TODO: description",
+  "description": "A Fewer database adapter to connect to Postgres",
   "keywords": [
     "fewer",
     "adapter",

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -1,7 +1,7 @@
 import { Adapter as BaseAdapter } from 'fewer';
 import { Client, ConnectionConfig } from 'pg';
 
-class PostgresAdapter implements BaseAdapter {
+export class PostgresAdapter implements BaseAdapter {
     private client: Client;
 
     constructor(options: ConnectionConfig) {
@@ -12,9 +12,8 @@ class PostgresAdapter implements BaseAdapter {
         return this.client.connect();
     }
 
-    query(queryString: string, values: any[]) {
-        return this.client.query(queryString, values);
+    async query(queryString: string, values: any[]) {
+        const results = await this.client.query(queryString, values);
+        return results.rows;
     }
 }
-
-export const Adapter = PostgresAdapter;

--- a/packages/fewer/__typeval__/fail/mismatch-types.errors.json
+++ b/packages/fewer/__typeval__/fail/mismatch-types.errors.json
@@ -2,11 +2,11 @@
     {
         "location": {
             "start": {
-                "line": 19,
+                "line": 17,
                 "column": 23
             },
             "end": {
-                "line": 19,
+                "line": 17,
                 "column": 37
             }
         },
@@ -15,11 +15,11 @@
     {
         "location": {
             "start": {
-                "line": 20,
+                "line": 18,
                 "column": 23
             },
             "end": {
-                "line": 20,
+                "line": 18,
                 "column": 37
             }
         },

--- a/packages/fewer/__typeval__/fail/mismatch-types.ts
+++ b/packages/fewer/__typeval__/fail/mismatch-types.ts
@@ -1,5 +1,6 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../src';
+import { INTERNAL_TYPE } from '../../src/types';
 
 const schema = createSchema(20080906171750).table(
   'users',
@@ -12,7 +13,7 @@ const schema = createSchema(20080906171750).table(
   }),
 );
 
-type User = typeof schema.tables.users.$$Type;
+type User = typeof schema.tables.users[typeof INTERNAL_TYPE];
 const user = typeval.as<User>();
 
 // Test individual properties:

--- a/packages/fewer/__typeval__/fail/mismatch-types.ts
+++ b/packages/fewer/__typeval__/fail/mismatch-types.ts
@@ -1,6 +1,6 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../src';
-import { INTERNAL_TYPE } from '../../src/types';
+import { INTERNAL_TYPES } from '../../src/types';
 
 const schema = createSchema(20080906171750).table(
   'users',
@@ -12,9 +12,6 @@ const schema = createSchema(20080906171750).table(
     createdAt: t.datetime(),
   }),
 );
-
-type User = typeof schema.tables.users[typeof INTERNAL_TYPE];
-const user = typeval.as<User>();
 
 // Test individual properties:
 typeval.acceptsString(schema.version);

--- a/packages/fewer/__typeval__/fail/pluck-missing.errors.json
+++ b/packages/fewer/__typeval__/fail/pluck-missing.errors.json
@@ -1,0 +1,171 @@
+[
+    {
+        "location": {
+            "start": {
+                "line": 45,
+                "column": 8
+            },
+            "end": {
+                "line": 45,
+                "column": 18
+            }
+        },
+        "errorMessage": "Property 'middleName' does not exist on type '{ posts: ({ title: string; subtitle: string; content: string; } & ResolveAssociations<{}>)[]; firstName: string; lastName: string; bd: Date; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 46,
+                "column": 8
+            },
+            "end": {
+                "line": 46,
+                "column": 16
+            }
+        },
+        "errorMessage": "Property 'birthday' does not exist on type '{ posts: ({ title: string; subtitle: string; content: string; } & ResolveAssociations<{}>)[]; firstName: string; lastName: string; bd: Date; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 47,
+                "column": 19
+            },
+            "end": {
+                "line": 47,
+                "column": 29
+            }
+        },
+        "errorMessage": "Property 'middleName' does not exist on type '{ posts: { title: string; details: string; }[]; firstName: string; lastName: string; bd: Date; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 48,
+                "column": 19
+            },
+            "end": {
+                "line": 48,
+                "column": 27
+            }
+        },
+        "errorMessage": "Property 'birthday' does not exist on type '{ posts: { title: string; details: string; }[]; firstName: string; lastName: string; bd: Date; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 49,
+                "column": 28
+            },
+            "end": {
+                "line": 49,
+                "column": 36
+            }
+        },
+        "errorMessage": "Property 'subtitle' does not exist on type '{ title: string; details: string; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 50,
+                "column": 28
+            },
+            "end": {
+                "line": 50,
+                "column": 35
+            }
+        },
+        "errorMessage": "Property 'content' does not exist on type '{ title: string; details: string; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 51,
+                "column": 8
+            },
+            "end": {
+                "line": 51,
+                "column": 16
+            }
+        },
+        "errorMessage": "Property 'subtitle' does not exist on type '{ title: string; details: string; user: { firstName: string; middleName: string; lastName: string; birthday: Date; } & ResolveAssociations<{}>; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 52,
+                "column": 8
+            },
+            "end": {
+                "line": 52,
+                "column": 15
+            }
+        },
+        "errorMessage": "Property 'content' does not exist on type '{ title: string; details: string; user: { firstName: string; middleName: string; lastName: string; birthday: Date; } & ResolveAssociations<{}>; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 53,
+                "column": 19
+            },
+            "end": {
+                "line": 53,
+                "column": 27
+            }
+        },
+        "errorMessage": "Property 'subtitle' does not exist on type '{ title: string; details: string; user: { firstName: string; bd: Date; }; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 54,
+                "column": 19
+            },
+            "end": {
+                "line": 54,
+                "column": 26
+            }
+        },
+        "errorMessage": "Property 'content' does not exist on type '{ title: string; details: string; user: { firstName: string; bd: Date; }; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 55,
+                "column": 24
+            },
+            "end": {
+                "line": 55,
+                "column": 34
+            }
+        },
+        "errorMessage": "Property 'middleName' does not exist on type '{ firstName: string; bd: Date; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 56,
+                "column": 24
+            },
+            "end": {
+                "line": 56,
+                "column": 32
+            }
+        },
+        "errorMessage": "Property 'lastName' does not exist on type '{ firstName: string; bd: Date; }'."
+    },
+    {
+        "location": {
+            "start": {
+                "line": 57,
+                "column": 24
+            },
+            "end": {
+                "line": 57,
+                "column": 32
+            }
+        },
+        "errorMessage": "Property 'birthday' does not exist on type '{ firstName: string; bd: Date; }'."
+    }
+]

--- a/packages/fewer/__typeval__/fail/pluck-missing.ts
+++ b/packages/fewer/__typeval__/fail/pluck-missing.ts
@@ -1,0 +1,58 @@
+import {
+  createRepository,
+  createAssociation,
+  AssociationType,
+} from '../../src';
+
+const Users = createRepository<{
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  birthday: Date;
+}>('users');
+
+const Posts = createRepository<{
+  title: string;
+  subtitle: string;
+  content: string;
+}>('posts');
+
+const userPosts = createAssociation(AssociationType.HAS_MANY, Posts);
+const postUser = createAssociation(AssociationType.BELONGS_TO, Users);
+
+async function main() {
+  const user = await Users.find(1)
+    .pluck('firstName', 'lastName')
+    .pluckAs('birthday', 'bd')
+    .load('posts', userPosts);
+
+  const userLoadPlucked = await Users.find(1)
+    .pluck('firstName', 'lastName')
+    .pluckAs('birthday', 'bd')
+    .load('posts', userPosts.pluck('title').pluckAs('content', 'details'));
+
+  const post = await Posts.find(1)
+    .pluck('title')
+    .pluckAs('content', 'details')
+    .load('user', postUser);
+
+  const postLoadPlucked = await Posts.find(1)
+    .pluck('title')
+    .pluckAs('content', 'details')
+    .load('user', postUser.pluck('firstName').pluckAs('birthday', 'bd'));
+
+  // These should all be type errors:
+  user.middleName;
+  user.birthday;
+  userLoadPlucked.middleName;
+  userLoadPlucked.birthday;
+  userLoadPlucked.posts[0].subtitle;
+  userLoadPlucked.posts[0].content;
+  post.subtitle;
+  post.content;
+  postLoadPlucked.subtitle;
+  postLoadPlucked.content;
+  postLoadPlucked.user.middleName;
+  postLoadPlucked.user.lastName;
+  postLoadPlucked.user.birthday;
+}

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -3,8 +3,8 @@ import { createRepository, createAssociation, AssociationType } from '../../src'
 const Users = createRepository<{ firstName: string }>('users');
 const Posts = createRepository<{ title: string }>('posts');
 
-const userPosts = createAssociation(Users, AssociationType.HAS_MANY, Posts);
-const postUser = createAssociation(Posts, AssociationType.BELONGS_TO, Users);
+const userPosts = createAssociation(AssociationType.HAS_MANY, Posts);
+const postUser = createAssociation(AssociationType.BELONGS_TO, Users);
 
 async function main() {
     const user = await Users.find(1).load('posts', userPosts);

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -1,0 +1,12 @@
+import { createRepository, createAssociation, AssociationType } from '../../src';
+
+const Users = createRepository<{ firstName: string }>('users');
+const Posts = createRepository<{ title: string }>('posts');
+
+const userPosts = createAssociation(Users, AssociationType.HAS_MANY, Posts);
+const postUser = createAssociation(Posts, AssociationType.BELONGS_TO, Users);
+
+async function main() {
+    const user = await Users.find(1).load('posts', userPosts);
+    const post = await Posts.find(1).load('user', postUser);
+}

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -1,12 +1,28 @@
-import { createRepository, createAssociation, AssociationType } from '../../src';
+import * as typeval from '@fewer/typeval';
+import {
+  createRepository,
+  createAssociation,
+  AssociationType,
+} from '../../src';
 
-const Users = createRepository<{ firstName: string }>('users');
-const Posts = createRepository<{ title: string }>('posts');
+interface User {
+  firstName: string;
+}
+
+interface Post {
+  title: string;
+}
+
+const Users = createRepository<User>('users');
+const Posts = createRepository<Post>('posts');
 
 const userPosts = createAssociation(AssociationType.HAS_MANY, Posts);
 const postUser = createAssociation(AssociationType.BELONGS_TO, Users);
 
 async function main() {
-    const user = await Users.find(1).load('posts', userPosts);
-    const post = await Posts.find(1).load('user', postUser);
+  const user = await Users.find(1).load('posts', userPosts);
+  const post = await Posts.find(1).load('user', postUser);
+
+  typeval.accepts<Post>(user.posts);
+  typeval.accepts<User>(post.user);
 }

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -7,7 +7,7 @@ import {
 
 interface User {
   firstName: string;
-  lastName: string
+  lastName: string;
 }
 
 interface Post {
@@ -22,8 +22,11 @@ const userPosts = createAssociation(AssociationType.HAS_MANY, Posts);
 const postUser = createAssociation(AssociationType.BELONGS_TO, Users);
 
 async function main() {
-  const user = await Users.find(1).load('posts', userPosts);
-  const post = await Posts.find(1).load('user', postUser);
+  const user = await Users.find(1)
+    .pluck('firstName')
+    .load('posts', userPosts);
+
+  const post = await Posts.find(1).load('user', postUser.pluck('firstName'));
 
   // Query through join:
   Users.find(1)
@@ -43,6 +46,7 @@ async function main() {
       },
     });
 
+  typeval.acceptsString(user.firstName);
   typeval.accepts<Post[]>(user.posts);
-  typeval.accepts<User>(post.user);
+  typeval.accepts<{ firstName: string; lastName?: never }>(post.user);
 }

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -23,6 +23,24 @@ async function main() {
   const user = await Users.find(1).load('posts', userPosts);
   const post = await Posts.find(1).load('user', postUser);
 
+  // Query through join:
+  Users.find(1)
+    .join('posts', userPosts)
+    .where({
+      posts: {
+        title: 'testing',
+      },
+    });
+
+  // Query through load:
+  Users.find(1)
+    .load('posts', userPosts)
+    .where({
+      posts: {
+        title: 'testing',
+      },
+    });
+
   typeval.accepts<Post>(user.posts);
   typeval.accepts<User>(post.user);
 }

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -12,6 +12,7 @@ interface User {
 
 interface Post {
   title: string;
+  subtitle: string;
 }
 
 const Users = createRepository<User>('users');

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -7,6 +7,7 @@ import {
 
 interface User {
   firstName: string;
+  lastName: string
 }
 
 interface Post {
@@ -41,6 +42,6 @@ async function main() {
       },
     });
 
-  typeval.accepts<Post>(user.posts);
+  typeval.accepts<Post[]>(user.posts);
   typeval.accepts<User>(post.user);
 }

--- a/packages/fewer/__typeval__/pass/repository-pluck.ts
+++ b/packages/fewer/__typeval__/pass/repository-pluck.ts
@@ -9,7 +9,8 @@ const Users = createRepository<{
 }>('users');
 
 async function main() {
-    const user = await Users.find(1).pluck('firstName', 'lastName').pluckAs('birthday', 'bd');
+    // const user = await Users.find(1).pluck('firstName', 'lastName').pluckAs('birthday', 'bd');
+    const user = Users.find(1).pluck(['firstName', 'lastName', ['birthday', 'bd']]);
 
     typeval.acceptsString(user.firstName);
     typeval.acceptsString(user.lastName);

--- a/packages/fewer/__typeval__/pass/repository-pluck.ts
+++ b/packages/fewer/__typeval__/pass/repository-pluck.ts
@@ -1,0 +1,17 @@
+import * as typeval from '@fewer/typeval';
+import { createRepository } from '../../src';
+
+const Users = createRepository<{
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  birthday: Date;
+}>('users');
+
+async function main() {
+    const user = await Users.find(1).pluck('firstName', 'lastName').pluckAs('birthday', 'bd');
+
+    typeval.acceptsString(user.firstName);
+    typeval.acceptsString(user.lastName);
+    typeval.accepts<Date>(user.bd);
+}

--- a/packages/fewer/__typeval__/pass/repository-pluck.ts
+++ b/packages/fewer/__typeval__/pass/repository-pluck.ts
@@ -9,10 +9,11 @@ const Users = createRepository<{
 }>('users');
 
 async function main() {
-    // const user = await Users.find(1).pluck('firstName', 'lastName').pluckAs('birthday', 'bd');
-    const user = Users.find(1).pluck(['firstName', 'lastName', ['birthday', 'bd']]);
+  const user = await Users.find(1)
+    .pluck('firstName', 'lastName')
+    .pluckAs('birthday', 'bd');
 
-    typeval.acceptsString(user.firstName);
-    typeval.acceptsString(user.lastName);
-    typeval.accepts<Date>(user.bd);
+  typeval.acceptsString(user.firstName);
+  typeval.acceptsString(user.lastName);
+  typeval.accepts<Date>(user.bd);
 }

--- a/packages/fewer/__typeval__/pass/repository-symbol-accessors.ts
+++ b/packages/fewer/__typeval__/pass/repository-symbol-accessors.ts
@@ -1,14 +1,16 @@
 import * as typeval from '@fewer/typeval';
 import { createRepository, ValidationError } from '../../src';
 
-const Users = createRepository('users');
+const Users = createRepository<{ firstName: string; lastName: string }>(
+  'users',
+);
 const user = Users.from({});
 
 typeval.accepts<true>(user[Users.symbols.isModel]);
 typeval.acceptsBoolean(user[Users.symbols.dirty]);
 typeval.acceptsBoolean(user[Users.symbols.valid]);
-typeval.accepts<Set<string | number | symbol>>(user[Users.symbols.changed]);
-typeval.accepts<Map<string | number | symbol, any>>(
+typeval.accepts<Set<'firstName' | 'lastName'>>(user[Users.symbols.changed]);
+typeval.accepts<Map<'firstName' | 'lastName', any>>(
   user[Users.symbols.changes],
 );
 typeval.accepts<ReadonlyArray<ValidationError>>(user[Users.symbols.errors]);

--- a/packages/fewer/__typeval__/pass/schema-types-basic.ts
+++ b/packages/fewer/__typeval__/pass/schema-types-basic.ts
@@ -1,19 +1,15 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../src';
-import { INTERNAL_TYPE } from 'packages/fewer/src/types';
+import { INTERNAL_TYPES } from 'packages/fewer/src/types';
 
-const schema = createSchema(20080906171750).table(
-  'users',
-  { force: true },
-  t => ({
-    firstName: t.nonNull(t.string()),
-    lastName: t.string(),
-    deleted: t.boolean(),
-    createdAt: t.datetime(),
-  }),
-);
+const schema = createSchema(20080906171750).table('users', {}, t => ({
+  firstName: t.nonNull(t.string()),
+  lastName: t.string(),
+  deleted: t.boolean(),
+  createdAt: t.datetime(),
+}));
 
-type User = typeof schema.tables.users[typeof INTERNAL_TYPE];
+type User = typeof schema.tables.users[INTERNAL_TYPES.INTERNAL_TYPE];
 const user = typeval.as<User>();
 
 // Test individual properties:

--- a/packages/fewer/__typeval__/pass/schema-types-basic.ts
+++ b/packages/fewer/__typeval__/pass/schema-types-basic.ts
@@ -1,5 +1,6 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../src';
+import { INTERNAL_TYPE } from 'packages/fewer/src/types';
 
 const schema = createSchema(20080906171750).table(
   'users',
@@ -12,7 +13,7 @@ const schema = createSchema(20080906171750).table(
   }),
 );
 
-type User = typeof schema.tables.users.$$Type;
+type User = typeof schema.tables.users[typeof INTERNAL_TYPE];
 const user = typeval.as<User>();
 
 // Test individual properties:

--- a/packages/fewer/__typeval__/pass/schema-types-flex.ts
+++ b/packages/fewer/__typeval__/pass/schema-types-flex.ts
@@ -1,5 +1,6 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../src';
+import { INTERNAL_TYPE } from 'packages/fewer/src/types';
 
 const schema = createSchema(20080906171750).table(
   'flex',
@@ -25,7 +26,7 @@ const schema = createSchema(20080906171750).table(
   }),
 );
 
-type Flex = typeof schema.tables.flex.$$Type;
+type Flex = typeof schema.tables.flex[typeof INTERNAL_TYPE];
 const flex = typeval.as<Flex>();
 
 typeval.acceptsNumber(flex.integer);

--- a/packages/fewer/__typeval__/pass/schema-types-flex.ts
+++ b/packages/fewer/__typeval__/pass/schema-types-flex.ts
@@ -1,10 +1,10 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../src';
-import { INTERNAL_TYPE } from 'packages/fewer/src/types';
+import { INTERNAL_TYPES } from 'packages/fewer/src/types';
 
 const schema = createSchema(20080906171750).table(
   'flex',
-  { force: true },
+  {},
   t => ({
     integer: t.nonNull(t.integer()),
     smallint: t.nonNull(t.smallint()),
@@ -26,7 +26,7 @@ const schema = createSchema(20080906171750).table(
   }),
 );
 
-type Flex = typeof schema.tables.flex[typeof INTERNAL_TYPE];
+type Flex = typeof schema.tables.flex[INTERNAL_TYPES.INTERNAL_TYPE];
 const flex = typeval.as<Flex>();
 
 typeval.acceptsNumber(flex.integer);

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -10,27 +10,24 @@ export enum AssociationType {
 export class Association<
   Base extends Repository = Repository,
   Associate extends Repository = Repository
-> {
+> extends Repository {
   [INTERNAL_TYPE]: Associate;
 
   private type: AssociationType;
-  private base: Base;
   private associate: Associate;
 
-  constructor(type: AssociationType, base: Base, associate: Associate) {
+  constructor(type: AssociationType, associate: Associate) {
+    super(associate);
     this.type = type;
-    this.base = base;
     this.associate = associate;
   }
 }
 
 export function createAssociation<
-  Base extends Repository,
   Associate extends Repository
 >(
-  base: Base,
   type: AssociationType,
   associate: Associate,
-): Association<Base, Associate> {
-  return new Association(type, base, associate);
+): Association<Associate> {
+  return new Association(type, associate);
 }

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -1,5 +1,13 @@
 import { Repository } from '../Repository';
-import { INTERNAL_TYPE } from '../types';
+import {
+  INTERNAL_TYPES,
+  Associations,
+  CommonQuery,
+  WhereType,
+  CreateSelectionSet,
+  ResolveAssociations,
+  Subset,
+} from '../types';
 
 export enum AssociationType {
   HAS_ONE = 'hasOne',
@@ -9,26 +17,112 @@ export enum AssociationType {
 
 export class Association<
   Type extends AssociationType = any,
-  Associate extends Repository = Repository
-> extends Repository {
-  [INTERNAL_TYPE]: Associate;
-  private associate: Associate;
+  RepoType = any,
+  SelectionSet = any,
+  LoadAssociations extends Associations = {},
+  JoinAssociations extends Associations = {}
+> implements CommonQuery<RepoType, LoadAssociations & JoinAssociations> {
+  [INTERNAL_TYPES.INTERNAL_TYPE]: RepoType;
+  [INTERNAL_TYPES.RESOLVED_TYPE]: Subset<
+    RepoType & ResolveAssociations<LoadAssociations>,
+    SelectionSet
+  >;
 
   /**
    * The type of relationship that the association represents, such as "hasMany", and "belongsTo".
    */
   readonly type: Type;
 
-  constructor(type: Type, associate: Associate) {
-    super(associate);
+  private associate: Repository;
+
+  constructor(type: Type, associate: Repository) {
     this.type = type;
     this.associate = associate;
+  }
+
+  pluck<Key extends keyof RepoType>(
+    ...fields: Key[]
+  ): Association<
+    Type,
+    RepoType,
+    CreateSelectionSet<SelectionSet, Key>,
+    LoadAssociations,
+    JoinAssociations
+  > {
+    // @ts-ignore
+    return new Association(this.type, this.associate.pluck(...fields));
+  }
+
+  pluckAs<Key extends keyof RepoType, Alias extends string>(
+    name: Key,
+    alias: Alias,
+  ): Association<
+    Type,
+    RepoType & { [P in Alias]: RepoType[Key] },
+    CreateSelectionSet<SelectionSet, Alias>,
+    LoadAssociations,
+    JoinAssociations
+  > {
+    // @ts-ignore
+    return new Association(this.type, this.associate.pluckAs(name, alias));
+  }
+
+  limit(amount: number) {
+    return new Association(this.type, this.associate.limit(amount));
+  }
+
+  offset(amount: number) {
+    return new Association(this.type, this.associate.offset(amount));
+  }
+
+  order() {
+    throw new Error('not yet implemented');
+    // return new Association(this.type, this.associate.order());
+  }
+
+  where(wheres: WhereType<RepoType>) {
+    return new Association(this.type, this.associate.where(wheres));
+  }
+
+  load<Name extends string, LoadAssociation extends Association>(
+    name: string,
+    association: LoadAssociation,
+  ): Association<
+    Type,
+    RepoType,
+    SelectionSet,
+    LoadAssociations & { [P in Name]: LoadAssociations },
+    JoinAssociations
+  > {
+    return new Association(this.type, this.associate.load(name, association));
+  }
+
+  join<Name extends string, JoinAssociation extends Association>(
+    name: Name,
+    association: JoinAssociation,
+  ): Association<
+    Type,
+    RepoType,
+    SelectionSet,
+    LoadAssociations,
+    JoinAssociations & { [P in Name]: JoinAssociation }
+  > {
+    return new Association(this.type, this.associate.join(name, association));
   }
 }
 
 export function createAssociation<
   Type extends AssociationType,
   Associate extends Repository
->(type: Type, associate: Associate): Association<Type, Associate> {
+>(
+  type: Type,
+  associate: Associate,
+): Association<
+  Type,
+  Associate[INTERNAL_TYPES.INTERNAL_TYPE],
+  INTERNAL_TYPES.ALL_FIELDS,
+  {},
+  {}
+> {
   return new Association(type, associate);
 }

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -1,0 +1,36 @@
+import { Repository } from '../Repository';
+import { INTERNAL_TYPE } from '../types';
+
+export enum AssociationType {
+  HAS_ONE = 'hasOne',
+  HAS_MANY = 'hasMany',
+  BELONGS_TO = 'belongsTo',
+}
+
+export class Association<
+  Base extends Repository = Repository,
+  Associate extends Repository = Repository
+> {
+  [INTERNAL_TYPE]: Associate;
+
+  private type: AssociationType;
+  private base: Base;
+  private associate: Associate;
+
+  constructor(type: AssociationType, base: Base, associate: Associate) {
+    this.type = type;
+    this.base = base;
+    this.associate = associate;
+  }
+}
+
+export function createAssociation<
+  Base extends Repository,
+  Associate extends Repository
+>(
+  base: Base,
+  type: AssociationType,
+  associate: Associate,
+): Association<Base, Associate> {
+  return new Association(type, base, associate);
+}

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -8,14 +8,18 @@ export enum AssociationType {
 }
 
 export class Association<
+  Type extends AssociationType = any,
   Associate extends Repository = Repository
 > extends Repository {
   [INTERNAL_TYPE]: Associate;
-
-  private type: AssociationType;
   private associate: Associate;
 
-  constructor(type: AssociationType, associate: Associate) {
+  /**
+   * The type of relationship that the association represents, such as "hasMany", and "belongsTo".
+   */
+  readonly type: Type;
+
+  constructor(type: Type, associate: Associate) {
     super(associate);
     this.type = type;
     this.associate = associate;
@@ -23,10 +27,8 @@ export class Association<
 }
 
 export function createAssociation<
+  Type extends AssociationType,
   Associate extends Repository
->(
-  type: AssociationType,
-  associate: Associate,
-): Association<Associate> {
+>(type: Type, associate: Associate): Association<Type, Associate> {
   return new Association(type, associate);
 }

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -8,7 +8,6 @@ export enum AssociationType {
 }
 
 export class Association<
-  Base extends Repository = Repository,
   Associate extends Repository = Repository
 > extends Repository {
   [INTERNAL_TYPE]: Associate;

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -25,7 +25,8 @@ export class Association<
   [INTERNAL_TYPES.INTERNAL_TYPE]: RepoType;
   [INTERNAL_TYPES.RESOLVED_TYPE]: Subset<
     RepoType & ResolveAssociations<LoadAssociations>,
-    SelectionSet
+    SelectionSet,
+    keyof LoadAssociations
   >;
 
   /**

--- a/packages/fewer/src/Database/Adapter.ts
+++ b/packages/fewer/src/Database/Adapter.ts
@@ -1,6 +1,10 @@
-// TODO: Query response needs to be well formed.
-
 export default interface Adapter {
+  /**
+   * Initiate the connection to the Database.
+   */
   connect(): Promise<void>;
-  query(queryString: string, values?: any[]): Promise<any>;
+  /**
+   * Performs a query against the database. Returns an array of results from the database.
+   */
+  query(queryString: string, values?: any[]): Promise<any[]>;
 }

--- a/packages/fewer/src/Database/index.ts
+++ b/packages/fewer/src/Database/index.ts
@@ -23,7 +23,7 @@ export class Database {
   /**
    * Issues a SQL query against the database.
    */
-  query(queryString: string, values?: any[]): Promise<any> {
+  query(queryString: string, values?: any[]): Promise<any[]> {
     return this.adapter.query(queryString, values);
   }
 }

--- a/packages/fewer/src/Repository/index.ts
+++ b/packages/fewer/src/Repository/index.ts
@@ -117,6 +117,12 @@ export class Repository<
   /**
    * Validates an object.
    */
+  // TODO: Async + Dirty Validation
+  // We need a model that says hasRunValidation: false in the beginning, and then gets
+  // set to true after we run validate on it. And after any field changes, we reset
+  // the field back to false, forcing validation to run again.
+  // When we run validate, we check hasRunValidation, and if it's true, we skip running
+  // all of the validations, and then we return the current arrays index.
   validate<T extends Partial<RepoType> & SymbolProperties<RepoType>>(obj: T) {
     if (!obj[Symbols.isModel]) {
       throw new Error(
@@ -168,6 +174,13 @@ export class Repository<
       .toString();
 
     return db.query(query);
+  }
+
+  /**
+   * Updates a model in the database.
+   */
+  async update<T extends Partial<RepoType> & SymbolProperties<RepoType>>(obj: T): Promise<any> {
+    throw new Error('Not yet implemented');
   }
 
   /**
@@ -330,14 +343,14 @@ export class Repository<
     return new Repository(this.tableName, this.runningQuery, this.pipes);
   }
 
-  /**
-   * TODO: Documentation.
-   */
   [RESOLVED_TYPE]: Subset<
     RepoType & ResolveAssociations<LoadAssociations>,
     SelectionSet
   >;
 
+  /**
+   * TODO: Documentation.
+   */
   async then(
     onFulfilled: (
       value: QueryType extends QueryTypes.SINGLE

--- a/packages/fewer/src/Repository/index.ts
+++ b/packages/fewer/src/Repository/index.ts
@@ -19,15 +19,10 @@ type CreateSelectionSet<
   Additional
 > = Original extends typeof ALL_FIELDS ? Additional : Original | Additional;
 
-// type Subset<Root, Keys extends keyof Root> = Keys extends typeof ALL_FIELDS
-//   ? Root
-//   : { [P in keyof Root & Keys]: Root[P] };
-
-type Subset<Root, Keys> = Keys extends typeof ALL_FIELDS
+// NOTE: We intentionally wrap types here in `[]` to avoid TS distributing the keys.
+type Subset<Root, Keys> = [Keys] extends [typeof ALL_FIELDS]
   ? Root
-  : [Keys] extends [string]
-  ? { [P in (keyof Root) & Keys]: Root[P] }
-  : never;
+  : { [P in (keyof Root) & Keys]: Root[P] };
 
 type WhereType<T> = {
   [P in keyof T]?: NonNullable<T[P]> | NonNullable<T[P]>[]

--- a/packages/fewer/src/Repository/index.ts
+++ b/packages/fewer/src/Repository/index.ts
@@ -388,7 +388,8 @@ export class Repository<
 
   [INTERNAL_TYPES.RESOLVED_TYPE]: Subset<
     RepoType & ResolveAssociations<LoadAssociations>,
-    SelectionSet
+    SelectionSet,
+    keyof LoadAssociations
   >;
 
   /**
@@ -397,10 +398,15 @@ export class Repository<
   async then(
     onFulfilled: (
       value: QueryType extends QueryTypes.SINGLE
-        ? Subset<RepoType & ResolveAssociations<LoadAssociations>, SelectionSet>
+        ? Subset<
+            RepoType & ResolveAssociations<LoadAssociations>,
+            SelectionSet,
+            keyof LoadAssociations
+          >
         : Subset<
             RepoType & ResolveAssociations<LoadAssociations>,
-            SelectionSet
+            SelectionSet,
+            keyof LoadAssociations
           >[],
     ) => void,
     onRejected?: (error: Error) => void,

--- a/packages/fewer/src/Repository/pipe.ts
+++ b/packages/fewer/src/Repository/pipe.ts
@@ -1,0 +1,34 @@
+import { ValidationError } from './createModel';
+
+export interface Pipe<RepoType = any, Extensions = RepoType> {
+  /**
+   * Set an object up. Add virtuals and other properties.
+   */
+  prepare?(obj: RepoType & Partial<Extensions>): void;
+  /**
+   * Middleware.
+   */
+  use?(
+    obj: RepoType & Partial<Extensions>,
+    next: () => Promise<void>,
+  ): Promise<void>;
+  // TODO: This also needs to be async:
+  /**
+   * Perform validation. Return either undefined or null to signal no validation errors.
+   * Return either an array of Validation Errors, or a single validation error.
+   *
+   * @example
+   * return {
+   *   on: 'name',
+   *   message: 'No name was provided',
+   * }
+   */
+  validate?(
+    obj: RepoType & Partial<Extensions>,
+  ):
+    | void
+    | undefined
+    | null
+    | ValidationError<RepoType & Extensions>
+    | ValidationError<RepoType & Extensions>[];
+}

--- a/packages/fewer/src/Schema/FieldTypes.ts
+++ b/packages/fewer/src/Schema/FieldTypes.ts
@@ -1,5 +1,7 @@
+import { INTERNAL_TYPE } from "../types";
+
 export class Type<T = any, CanBeNull = true> {
-  $$Type!: CanBeNull extends true ? T | undefined : T;
+  [INTERNAL_TYPE]: CanBeNull extends true ? T | undefined : T;
 
   constructor(config?: object) {
     // TODO:

--- a/packages/fewer/src/Schema/FieldTypes.ts
+++ b/packages/fewer/src/Schema/FieldTypes.ts
@@ -1,7 +1,7 @@
-import { INTERNAL_TYPE } from "../types";
+import { INTERNAL_TYPES } from "../types";
 
 export class Type<T = any, CanBeNull = true> {
-  [INTERNAL_TYPE]: CanBeNull extends true ? T | undefined : T;
+  [INTERNAL_TYPES.INTERNAL_TYPE]: CanBeNull extends true ? T | undefined : T;
 
   constructor(config?: object) {
     // TODO:

--- a/packages/fewer/src/Schema/index.ts
+++ b/packages/fewer/src/Schema/index.ts
@@ -1,5 +1,6 @@
 import * as FieldTypes from './FieldTypes';
 import { WithUndefinedPropertiesAsOptionals } from './typeHelpers';
+import { INTERNAL_TYPE } from '../types';
 
 type TableOptions =
   | {
@@ -13,12 +14,11 @@ export interface BaseBuilt {
 }
 
 type BuiltTable<Built extends BaseBuilt> = {
-  // TODO: There's probably a way to infer this rather than do it this way:
-  [P in keyof Built]: Built[P]['$$Type']
+  [P in keyof Built]: Built[P][typeof INTERNAL_TYPE]
 };
 
 export class SchemaTable<T extends BaseBuilt> {
-  $$Type!: WithUndefinedPropertiesAsOptionals<BuiltTable<T>>;
+  [INTERNAL_TYPE]: WithUndefinedPropertiesAsOptionals<BuiltTable<T>>;
 
   name: string;
 

--- a/packages/fewer/src/Schema/index.ts
+++ b/packages/fewer/src/Schema/index.ts
@@ -1,6 +1,6 @@
 import * as FieldTypes from './FieldTypes';
 import { WithUndefinedPropertiesAsOptionals } from './typeHelpers';
-import { INTERNAL_TYPE } from '../types';
+import { INTERNAL_TYPES } from '../types';
 
 type TableOptions =
   | {
@@ -14,11 +14,11 @@ export interface BaseBuilt {
 }
 
 type BuiltTable<Built extends BaseBuilt> = {
-  [P in keyof Built]: Built[P][typeof INTERNAL_TYPE]
+  [P in keyof Built]: Built[P][INTERNAL_TYPES.INTERNAL_TYPE]
 };
 
 export class SchemaTable<T extends BaseBuilt> {
-  [INTERNAL_TYPE]: WithUndefinedPropertiesAsOptionals<BuiltTable<T>>;
+  [INTERNAL_TYPES.INTERNAL_TYPE]: WithUndefinedPropertiesAsOptionals<BuiltTable<T>>;
 
   name: string;
 

--- a/packages/fewer/src/index.ts
+++ b/packages/fewer/src/index.ts
@@ -1,27 +1,18 @@
-import { Schema, createSchema } from './Schema';
-import {
-  Repository,
-  createRepository,
-  ValidationError,
-  Pipe,
-} from './Repository';
-import { Database, createDatabase, Adapter } from './Database';
+import { createSchema } from './Schema';
+import { createRepository, ValidationError, Pipe } from './Repository';
+import { createDatabase, Adapter } from './Database';
+import { createAssociation, AssociationType } from './Association';
 
 export {
   // The create helpers are what should be used to create instances:
   createDatabase,
   createSchema,
   createRepository,
+  createAssociation,
   // Export adapter for adapter implementations:
   Adapter,
   // Export types:
+  AssociationType,
   ValidationError,
   Pipe,
-};
-
-// Just in case someone needs access to the underlying constructors:
-export const Constructors = {
-  Database,
-  Schema,
-  Repository,
 };

--- a/packages/fewer/src/types.ts
+++ b/packages/fewer/src/types.ts
@@ -1,0 +1,1 @@
+export const INTERNAL_TYPE: unique symbol = Symbol('internal-type');

--- a/packages/fewer/src/types.ts
+++ b/packages/fewer/src/types.ts
@@ -34,9 +34,11 @@ export type WhereType<Root, Assoc extends Associations = {}> = WhereForType<
 > &
   { [P in keyof Assoc]?: WhereForType<UnrollAssociation<Assoc[P]>> };
 
-export type Subset<Root, Keys> = [Keys] extends [INTERNAL_TYPES.ALL_FIELDS]
+export type Subset<Root, Keys, AssociationKeys extends keyof Root> = [
+  Keys
+] extends [INTERNAL_TYPES.ALL_FIELDS]
   ? Root
-  : { [P in (keyof Root) & Keys]: Root[P] };
+  : { [P in ((keyof Root) & Keys) | AssociationKeys]: Root[P] };
 
 export type ResolveAssociations<Assoc extends Associations> = {
   [P in keyof Assoc]: [Assoc[P]['type']] extends [AssociationType.HAS_MANY]

--- a/packages/fewer/src/types.ts
+++ b/packages/fewer/src/types.ts
@@ -1,1 +1,56 @@
-export const INTERNAL_TYPE: unique symbol = Symbol('internal-type');
+import { Association, AssociationType } from './Association';
+
+// TODO: Move this back into unique symbols once this bug is resolved:
+// https://github.com/Microsoft/TypeScript/issues/29108
+export const enum INTERNAL_TYPES {
+  ALL_FIELDS = '@@ALL_FIELDS',
+  RESOLVED_TYPE = '@@RESOLVED_TYPE',
+  INTERNAL_TYPE = '@@INTERNAL_TYPE',
+}
+
+// We default to selecting all fields, but once you pluck one field, we need to remove
+// the ALL_FIELDS symbol and only carry forward the plucked fields.
+export type CreateSelectionSet<
+  Original,
+  Additional
+> = Original extends INTERNAL_TYPES.ALL_FIELDS
+  ? Additional
+  : Original | Additional;
+
+export interface Associations {
+  [key: string]: Association;
+}
+
+type UnrollAssociation<
+  T extends Association
+> = T[INTERNAL_TYPES.INTERNAL_TYPE][INTERNAL_TYPES.INTERNAL_TYPE];
+
+type WhereForType<T> = {
+  [P in keyof T]?: NonNullable<T[P]> | NonNullable<T[P]>[]
+};
+
+export type WhereType<Root, Assoc extends Associations = {}> = WhereForType<
+  Root
+> &
+  { [P in keyof Assoc]?: WhereForType<UnrollAssociation<Assoc[P]>> };
+
+export type Subset<Root, Keys> = [Keys] extends [INTERNAL_TYPES.ALL_FIELDS]
+  ? Root
+  : { [P in (keyof Root) & Keys]: Root[P] };
+
+export type ResolveAssociations<Assoc extends Associations> = {
+  [P in keyof Assoc]: [Assoc[P]['type']] extends [AssociationType.HAS_MANY]
+    ? Assoc[P][INTERNAL_TYPES.RESOLVED_TYPE][]
+    : Assoc[P][INTERNAL_TYPES.RESOLVED_TYPE]
+};
+
+export interface CommonQuery<Type, Assoc extends Associations> {
+  pluck(...fields: (keyof Type)[]): any;
+  pluckAs(name: keyof Type, alias: string): any;
+  where(wheres: WhereType<Type, Assoc>): any;
+  limit(amount: number): any;
+  offset(amount: number): any;
+  order(): any;
+  load(name: string, association: Association): any;
+  join(name: string, association: Association): any;
+}

--- a/packages/validations/package.json
+++ b/packages/validations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fewer/validations",
   "version": "0.0.3",
-  "description": "> TODO: description",
+  "description": "A collection of pipes that handle common model validation use-cases for Fewer",
   "keywords": [
     "fewer",
     "validations"

--- a/packages/virtuals/package.json
+++ b/packages/virtuals/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fewer/virtuals",
   "version": "0.0.3",
-  "description": "> TODO: description",
+  "description": "A pipe to add custom fields and methods to objects returned by the repository",
   "keywords": [
     "virtuals",
     "fewer"

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,6 +697,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/mysql@^2.15.5":
+  version "2.15.5"
+  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.5.tgz#6d75afb5cc018c9d66b2f37a046924e397f85430"
+  integrity sha512-4QAISTUGZbcFh7bqdndo08xRdES5OTU+JODy8VCZbe1yiXyGjqw1H83G43XjQ3IbC10wn9xlGd44A5RXJwNh0Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "10.12.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.15.tgz#20e85651b62fd86656e57c9c9bc771ab1570bc59"
@@ -1192,6 +1199,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bignumber.js@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
+  integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
 bin-links@^1.1.2:
   version "1.1.2"
@@ -4571,6 +4583,16 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
+mysql@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.16.0.tgz#b23b22ab5de44fc2d5d32bd4f5af6653fc45e2ba"
+  integrity sha512-dPbN2LHonQp7D5ja5DJXNbCLe/HRdu+f3v61aguzNRQIrmZLOeRoymBYyeThrR6ug+FqzDL95Gc9maqZUJS+Gw==
+  dependencies:
+    bignumber.js "4.1.0"
+    readable-stream "2.3.6"
+    safe-buffer "5.1.2"
+    sqlstring "2.3.1"
+
 nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
@@ -5513,7 +5535,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@2.3.6, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -5745,7 +5767,7 @@ rxjs@^6.1.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -6011,7 +6033,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlstring@^2.3.1:
+sqlstring@2.3.1, sqlstring@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
   integrity sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=


### PR DESCRIPTION
This does two things:

1. Adds the initial typings for associations. To create associations, you create them with a repository and the type of relationship. Then when querying, you can use the new `load()` method to include an association. Associations include all of the normal querying methods that repositories do, so you can prepare the query on your association off of the association itself. For example...

```js
const hasManyPosts = createAssociation('hasMany', Posts);

const user = await Users.find(1).load(hasManyPosts.where({ published: true }).pluck('title'));
```

This should give us the ability to do full type safety, and exposes a familiar API (same association query API as the top-level query API). 

2. I reworked how plucked attributes work so that they build a list of keys that are plucked. Before things were actually broken for chaining plucks, and this approach fixes that. It also works nicely for associations.