### PR TITLE
Rework associations 

### DIFF
--- a/packages/fewer/__typeval__/fail/pluck-missing.errors.json
+++ b/packages/fewer/__typeval__/fail/pluck-missing.errors.json
@@ -2,37 +2,37 @@
     {
         "location": {
             "start": {
-                "line": 45,
+                "line": 44,
                 "column": 8
             },
             "end": {
-                "line": 45,
+                "line": 44,
                 "column": 18
             }
         },
-        "errorMessage": "Property 'middleName' does not exist on type '{ posts: ({ title: string; subtitle: string; content: string; } & ResolveAssociations<{}>)[]; firstName: string; lastName: string; bd: Date; }'."
+        "errorMessage": "Property 'middleName' does not exist on type '{ posts: ({ title: string; subtitle: string; content: string; userId: number; } & ResolveAssociations<{}>)[]; firstName: string; lastName: string; bd: Date; }'."
     },
     {
         "location": {
             "start": {
-                "line": 46,
+                "line": 45,
                 "column": 8
             },
             "end": {
-                "line": 46,
+                "line": 45,
                 "column": 16
             }
         },
-        "errorMessage": "Property 'birthday' does not exist on type '{ posts: ({ title: string; subtitle: string; content: string; } & ResolveAssociations<{}>)[]; firstName: string; lastName: string; bd: Date; }'."
+        "errorMessage": "Property 'birthday' does not exist on type '{ posts: ({ title: string; subtitle: string; content: string; userId: number; } & ResolveAssociations<{}>)[]; firstName: string; lastName: string; bd: Date; }'."
     },
     {
         "location": {
             "start": {
-                "line": 47,
+                "line": 46,
                 "column": 19
             },
             "end": {
-                "line": 47,
+                "line": 46,
                 "column": 29
             }
         },
@@ -41,11 +41,11 @@
     {
         "location": {
             "start": {
-                "line": 48,
+                "line": 47,
                 "column": 19
             },
             "end": {
-                "line": 48,
+                "line": 47,
                 "column": 27
             }
         },
@@ -54,11 +54,11 @@
     {
         "location": {
             "start": {
-                "line": 49,
+                "line": 48,
                 "column": 28
             },
             "end": {
-                "line": 49,
+                "line": 48,
                 "column": 36
             }
         },
@@ -67,11 +67,11 @@
     {
         "location": {
             "start": {
-                "line": 50,
+                "line": 49,
                 "column": 28
             },
             "end": {
-                "line": 50,
+                "line": 49,
                 "column": 35
             }
         },
@@ -80,11 +80,11 @@
     {
         "location": {
             "start": {
-                "line": 51,
+                "line": 50,
                 "column": 8
             },
             "end": {
-                "line": 51,
+                "line": 50,
                 "column": 16
             }
         },
@@ -93,11 +93,11 @@
     {
         "location": {
             "start": {
-                "line": 52,
+                "line": 51,
                 "column": 8
             },
             "end": {
-                "line": 52,
+                "line": 51,
                 "column": 15
             }
         },
@@ -106,11 +106,11 @@
     {
         "location": {
             "start": {
-                "line": 53,
+                "line": 52,
                 "column": 19
             },
             "end": {
-                "line": 53,
+                "line": 52,
                 "column": 27
             }
         },
@@ -119,11 +119,11 @@
     {
         "location": {
             "start": {
-                "line": 54,
+                "line": 53,
                 "column": 19
             },
             "end": {
-                "line": 54,
+                "line": 53,
                 "column": 26
             }
         },
@@ -132,11 +132,11 @@
     {
         "location": {
             "start": {
-                "line": 55,
+                "line": 54,
                 "column": 24
             },
             "end": {
-                "line": 55,
+                "line": 54,
                 "column": 34
             }
         },
@@ -145,11 +145,11 @@
     {
         "location": {
             "start": {
-                "line": 56,
+                "line": 55,
                 "column": 24
             },
             "end": {
-                "line": 56,
+                "line": 55,
                 "column": 32
             }
         },
@@ -158,11 +158,11 @@
     {
         "location": {
             "start": {
-                "line": 57,
+                "line": 56,
                 "column": 24
             },
             "end": {
-                "line": 57,
+                "line": 56,
                 "column": 32
             }
         },

--- a/packages/fewer/__typeval__/fail/pluck-missing.ts
+++ b/packages/fewer/__typeval__/fail/pluck-missing.ts
@@ -1,7 +1,5 @@
 import {
-  createRepository,
-  createAssociation,
-  AssociationType,
+  createRepository, createHasMany, createBelongsTo,
 } from '../../src';
 
 const Users = createRepository<{
@@ -15,10 +13,11 @@ const Posts = createRepository<{
   title: string;
   subtitle: string;
   content: string;
+  userId: number;
 }>('posts');
 
-const userPosts = createAssociation(AssociationType.HAS_MANY, Posts);
-const postUser = createAssociation(AssociationType.BELONGS_TO, Users);
+const userPosts = createHasMany(Users, Posts, 'userId');
+const postUser = createBelongsTo(Users, 'userId');
 
 async function main() {
   const user = await Users.find(1)

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -1,9 +1,5 @@
 import * as typeval from '@fewer/typeval';
-import {
-  createRepository,
-  createHasMany,
-  createBelongsTo,
-} from '../../src';
+import { createRepository, createHasMany, createBelongsTo } from '../../src';
 
 interface User {
   firstName: string;
@@ -27,7 +23,12 @@ async function main() {
     .pluck('firstName')
     .load('posts', userPosts);
 
-  const post = await Posts.find(1).load('user', belongsToUser.pluck('firstName'));
+  const post = await Posts.find(1).load(
+    'user',
+    belongsToUser.pluck('firstName'),
+  );
+
+  Users.join('foo', userPosts);
 
   // Query through join:
   Users.find(1)

--- a/packages/fewer/__typeval__/pass/associations.ts
+++ b/packages/fewer/__typeval__/pass/associations.ts
@@ -1,8 +1,8 @@
 import * as typeval from '@fewer/typeval';
 import {
   createRepository,
-  createAssociation,
-  AssociationType,
+  createHasMany,
+  createBelongsTo,
 } from '../../src';
 
 interface User {
@@ -13,20 +13,21 @@ interface User {
 interface Post {
   title: string;
   subtitle: string;
+  userId: number;
 }
 
 const Users = createRepository<User>('users');
 const Posts = createRepository<Post>('posts');
 
-const userPosts = createAssociation(AssociationType.HAS_MANY, Posts);
-const postUser = createAssociation(AssociationType.BELONGS_TO, Users);
+const userPosts = createHasMany(Users, Posts, 'userId');
+const belongsToUser = createBelongsTo(Users, 'userId');
 
 async function main() {
   const user = await Users.find(1)
     .pluck('firstName')
     .load('posts', userPosts);
 
-  const post = await Posts.find(1).load('user', postUser.pluck('firstName'));
+  const post = await Posts.find(1).load('user', belongsToUser.pluck('firstName'));
 
   // Query through join:
   Users.find(1)

--- a/packages/fewer/src/Association/index.ts
+++ b/packages/fewer/src/Association/index.ts
@@ -16,6 +16,7 @@ export enum AssociationType {
 }
 
 export class Association<
+  FK = any,
   Type extends AssociationType = any,
   RepoType = any,
   SelectionSet = any,
@@ -44,6 +45,7 @@ export class Association<
   pluck<Key extends keyof RepoType>(
     ...fields: Key[]
   ): Association<
+    FK,
     Type,
     RepoType,
     CreateSelectionSet<SelectionSet, Key>,
@@ -58,6 +60,7 @@ export class Association<
     name: Key,
     alias: Alias,
   ): Association<
+    FK,
     Type,
     RepoType & { [P in Alias]: RepoType[Key] },
     CreateSelectionSet<SelectionSet, Alias>,
@@ -89,6 +92,7 @@ export class Association<
     name: string,
     association: LoadAssociation,
   ): Association<
+    FK,
     Type,
     RepoType,
     SelectionSet,
@@ -102,6 +106,7 @@ export class Association<
     name: Name,
     association: JoinAssociation,
   ): Association<
+    FK,
     Type,
     RepoType,
     SelectionSet,
@@ -112,18 +117,57 @@ export class Association<
   }
 }
 
-export function createAssociation<
-  Type extends AssociationType,
-  Associate extends Repository
+export function createBelongsTo<
+  Associate extends Repository,
+  FK extends string
 >(
-  type: Type,
   associate: Associate,
+  foreignKey: FK,
 ): Association<
-  Type,
+  FK,
+  AssociationType.BELONGS_TO,
   Associate[INTERNAL_TYPES.INTERNAL_TYPE],
   INTERNAL_TYPES.ALL_FIELDS,
   {},
   {}
 > {
-  return new Association(type, associate);
+  return new Association(AssociationType.BELONGS_TO, associate);
+}
+
+export function createHasOne<
+  BaseType extends Repository,
+  Associate extends Repository,
+  FK extends keyof Associate[INTERNAL_TYPES.INTERNAL_TYPE]
+>(
+  base: BaseType,
+  associate: Associate,
+  foreignKey: FK,
+): Association<
+  FK,
+  AssociationType.HAS_ONE,
+  Associate[INTERNAL_TYPES.INTERNAL_TYPE],
+  INTERNAL_TYPES.ALL_FIELDS,
+  {},
+  {}
+> {
+  return new Association(AssociationType.HAS_ONE, associate);
+}
+
+export function createHasMany<
+  BaseType extends Repository,
+  Associate extends Repository,
+  FK extends keyof Associate[INTERNAL_TYPES.INTERNAL_TYPE]
+>(
+  base: BaseType,
+  associate: Associate,
+  foreignKey: FK,
+): Association<
+  FK,
+  AssociationType.HAS_MANY,
+  Associate[INTERNAL_TYPES.INTERNAL_TYPE],
+  INTERNAL_TYPES.ALL_FIELDS,
+  {},
+  {}
+> {
+  return new Association(AssociationType.HAS_MANY, associate);
 }

--- a/packages/fewer/src/Repository/index.ts
+++ b/packages/fewer/src/Repository/index.ts
@@ -25,6 +25,8 @@ export enum QueryTypes {
   MULTIPLE,
 }
 
+const SCHEMA_TYPE = Symbol('schema-type');
+
 export class Repository<
   SchemaType = {},
   RepoType extends SchemaType = any,
@@ -33,8 +35,10 @@ export class Repository<
   JoinAssociations extends Associations = {},
   QueryType extends QueryTypes = any
 > implements CommonQuery<RepoType, LoadAssociations & JoinAssociations> {
+  // Stash the schema type so that the generic can be used as a type constraint.
+  [SCHEMA_TYPE]: SchemaType;
+
   [INTERNAL_TYPES.INTERNAL_TYPE]: RepoType;
-  [INTERNAL_TYPES.SCHEMA_TYPE]: SchemaType;
 
   /**
    * Contains symbols that are used to access metadata about the state of models.

--- a/packages/fewer/src/Repository/index.ts
+++ b/packages/fewer/src/Repository/index.ts
@@ -9,7 +9,7 @@ import createModel, {
   InternalSymbolProperties,
 } from './createModel';
 import { Pipe } from './pipe';
-import { Association } from '../Association';
+import { Association, AssociationType } from '../Association';
 import {
   INTERNAL_TYPES,
   CommonQuery,
@@ -26,13 +26,15 @@ export enum QueryTypes {
 }
 
 export class Repository<
-  RepoType = any,
+  SchemaType = {},
+  RepoType extends SchemaType = any,
   SelectionSet = INTERNAL_TYPES.ALL_FIELDS,
   LoadAssociations extends Associations = {},
   JoinAssociations extends Associations = {},
   QueryType extends QueryTypes = any
 > implements CommonQuery<RepoType, LoadAssociations & JoinAssociations> {
   [INTERNAL_TYPES.INTERNAL_TYPE]: RepoType;
+  [INTERNAL_TYPES.SCHEMA_TYPE]: SchemaType;
 
   /**
    * Contains symbols that are used to access metadata about the state of models.
@@ -69,6 +71,7 @@ export class Repository<
   pipe<Extensions>(
     pipe: Pipe<RepoType, Extensions>,
   ): Repository<
+    SchemaType,
     RepoType & Extensions,
     SelectionSet,
     LoadAssociations,
@@ -206,6 +209,7 @@ export class Repository<
   where(
     wheres: WhereType<RepoType, LoadAssociations & JoinAssociations>,
   ): Repository<
+    SchemaType,
     RepoType,
     SelectionSet,
     LoadAssociations,
@@ -236,6 +240,7 @@ export class Repository<
   find(
     id: string | number,
   ): Repository<
+    SchemaType,
     RepoType,
     SelectionSet,
     LoadAssociations,
@@ -258,6 +263,7 @@ export class Repository<
   pluck<Key extends keyof RepoType>(
     ...fields: Key[]
   ): Repository<
+    SchemaType,
     RepoType,
     CreateSelectionSet<SelectionSet, Key>,
     LoadAssociations,
@@ -283,6 +289,7 @@ export class Repository<
     name: Key,
     alias: Alias,
   ): Repository<
+    SchemaType,
     RepoType & { [P in Alias]: RepoType[Key] },
     CreateSelectionSet<SelectionSet, Alias>,
     LoadAssociations,
@@ -310,6 +317,7 @@ export class Repository<
   limit(
     amount: number,
   ): Repository<
+    SchemaType,
     RepoType,
     SelectionSet,
     LoadAssociations,
@@ -330,6 +338,7 @@ export class Repository<
   offset(
     amount: number,
   ): Repository<
+    SchemaType,
     RepoType,
     SelectionSet,
     LoadAssociations,
@@ -347,10 +356,23 @@ export class Repository<
   /**
    * Loads an association.
    */
-  load<Name extends string, LoadAssociation extends Association>(
+  load<
+    Name extends string,
+    LoadAssociation extends Association<
+      AssociationType,
+      Repository<SchemaType>,
+      KeyConstraint
+    >,
+    KeyConstraint = LoadAssociation extends Association<
+      AssociationType.BELONGS_TO
+    >
+      ? keyof RepoType
+      : any
+  >(
     name: Name,
     association: LoadAssociation,
   ): Repository<
+    SchemaType,
     RepoType,
     SelectionSet,
     LoadAssociations & { [P in Name]: LoadAssociation },
@@ -368,10 +390,23 @@ export class Repository<
   /**
    * Resolves the association, but does not load the records.
    */
-  join<Name extends string, JoinAssociation extends Association>(
+  join<
+    Name extends string,
+    JoinAssociation extends Association<
+      AssociationType,
+      Repository<SchemaType>,
+      KeyConstraint
+    >,
+    KeyConstraint = JoinAssociation extends Association<
+      AssociationType.BELONGS_TO
+    >
+      ? keyof RepoType
+      : any
+  >(
     name: Name,
     association: JoinAssociation,
   ): Repository<
+    SchemaType,
     RepoType,
     SelectionSet,
     LoadAssociations,
@@ -456,6 +491,7 @@ export function createRepository<Type extends SchemaTable<any>>(
   table: Type,
 ): Repository<
   Type[INTERNAL_TYPES.INTERNAL_TYPE],
+  Type[INTERNAL_TYPES.INTERNAL_TYPE],
   INTERNAL_TYPES.ALL_FIELDS,
   {},
   {},
@@ -463,7 +499,14 @@ export function createRepository<Type extends SchemaTable<any>>(
 >;
 export function createRepository<Type>(
   table: string,
-): Repository<Type, INTERNAL_TYPES.ALL_FIELDS, {}, {}, QueryTypes.MULTIPLE>;
+): Repository<
+  Type,
+  Type,
+  INTERNAL_TYPES.ALL_FIELDS,
+  {},
+  {},
+  QueryTypes.MULTIPLE
+>;
 export function createRepository(table: any): any {
   return new Repository(
     typeof table === 'string' ? table : table.name,

--- a/packages/fewer/src/index.ts
+++ b/packages/fewer/src/index.ts
@@ -1,18 +1,19 @@
 import { createSchema } from './Schema';
 import { createRepository, ValidationError, Pipe } from './Repository';
 import { createDatabase, Adapter } from './Database';
-import { createAssociation, AssociationType } from './Association';
+import { createBelongsTo, createHasOne, createHasMany } from './Association';
 
 export {
   // The create helpers are what should be used to create instances:
   createDatabase,
   createSchema,
   createRepository,
-  createAssociation,
+  createBelongsTo,
+  createHasOne,
+  createHasMany,
   // Export adapter for adapter implementations:
   Adapter,
   // Export types:
-  AssociationType,
   ValidationError,
   Pipe,
 };

--- a/packages/fewer/src/types.ts
+++ b/packages/fewer/src/types.ts
@@ -6,6 +6,7 @@ export const enum INTERNAL_TYPES {
   ALL_FIELDS = '@@ALL_FIELDS',
   RESOLVED_TYPE = '@@RESOLVED_TYPE',
   INTERNAL_TYPE = '@@INTERNAL_TYPE',
+  SCHEMA_TYPE = '@@SCHEMA_TYPE'
 }
 
 // We default to selecting all fields, but once you pluck one field, we need to remove

--- a/packages/fewer/src/types.ts
+++ b/packages/fewer/src/types.ts
@@ -5,8 +5,7 @@ import { Association, AssociationType } from './Association';
 export const enum INTERNAL_TYPES {
   ALL_FIELDS = '@@ALL_FIELDS',
   RESOLVED_TYPE = '@@RESOLVED_TYPE',
-  INTERNAL_TYPE = '@@INTERNAL_TYPE',
-  SCHEMA_TYPE = '@@SCHEMA_TYPE'
+  INTERNAL_TYPE = '@@INTERNAL_TYPE'
 }
 
 // We default to selecting all fields, but once you pluck one field, we need to remove


### PR DESCRIPTION
to: @Emily 

This reworks associations so that we keep the super minimal belongsTo association, and adds the base repo to the other associations. We also separated out the methods into `createBelongsTo`, `createHasOne`, and `createHasMany` so that we can simplify the type-checking around these.

For has*, we now require a foreign key is provided, and ensure that it is key of associate type (otherwise we can't actually perform the join). We'll also add more type constraints around the associations later (such as ensuring the root schema type is identical).