### PR TITLE
Improve some of the migration types

### DIFF
--- a/packages/adapter-postgres/src/__integration__/changeMigration.test.ts
+++ b/packages/adapter-postgres/src/__integration__/changeMigration.test.ts
@@ -31,9 +31,7 @@ describe('change migration', () => {
           }),
       });
 
-      migration.run('up');
-
-      await adapter.migrate(migration);
+      await migration.run('up');
 
       expect(
         await adapter.rawQuery(

--- a/packages/adapter-postgres/src/__tests__/changeMigrations.test.ts
+++ b/packages/adapter-postgres/src/__tests__/changeMigrations.test.ts
@@ -19,7 +19,7 @@ describe('migration', () => {
           }),
       });
 
-      migration.run('up');
+      migration.prepare('up');
 
       const sql = migrate(migration);
       expect(sql).toMatchSnapshot();
@@ -38,7 +38,7 @@ describe('migration', () => {
           }),
       });
 
-      migration.run('up');
+      migration.prepare('up');
 
       const sql = migrate(migration);
       expect(sql).toMatchSnapshot();
@@ -55,7 +55,7 @@ describe('migration', () => {
           }),
       });
 
-      migration.run('up');
+      migration.prepare('up');
 
       const sql = migrate(migration);
       expect(sql).toMatchSnapshot();
@@ -76,7 +76,7 @@ describe('migration', () => {
           ),
       });
 
-      migration.run('up');
+      migration.prepare('up');
 
       const sql = migrate(migration);
       expect(sql).toMatchSnapshot();

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -27,7 +27,7 @@ class PostgresAdapter implements BaseAdapter {
     return this.client.end();
   }
 
-  async migrate(migration: Migration) {
+  async migrate(direction: 'up' | 'down', migration: Migration) {
     const query = migrate(migration);
     const results = await this.client.query(query);
     return results;

--- a/packages/fewer/__tests__/tsconfig.json
+++ b/packages/fewer/__tests__/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../../tsconfig.json",
-  "include": ["./"]
-}

--- a/packages/fewer/src/Adapter/index.ts
+++ b/packages/fewer/src/Adapter/index.ts
@@ -22,7 +22,7 @@ export interface Adapter {
   /**
    * Perform a migration.
    */
-  migrate(migration: Migration): Promise<any>;
+  migrate(direction: 'up' | 'down', migration: Migration): Promise<any>;
   /**
    * Performs a query against the database. Returns an array of results from the database.
    */

--- a/packages/fewer/src/Database/index.ts
+++ b/packages/fewer/src/Database/index.ts
@@ -6,17 +6,13 @@ export interface DatabaseConfig<DBAdapter extends Adapter = Adapter> {
 }
 
 export class Database<DBAdapter extends Adapter = Adapter> {
-  private adapter: DBAdapter;
+  /**
+   * The registered underlying adapter.
+   */
+  readonly adapter: DBAdapter;
 
   constructor({ adapter }: DatabaseConfig<DBAdapter>) {
     this.adapter = adapter;
-  }
-
-  /**
-   * Retrieve the underlying adapter.
-   */
-  getAdapter() {
-    return this.adapter;
   }
 
   /**

--- a/packages/fewer/src/Repository/__tests__/createModel.test.ts
+++ b/packages/fewer/src/Repository/__tests__/createModel.test.ts
@@ -1,4 +1,4 @@
-import createModel, { Symbols, InternalSymbols } from '../../src/Repository/createModel';
+import createModel, { Symbols, InternalSymbols } from '../createModel';
 
 describe('createModel', () => {
   it('returns a new object', () => {


### PR DESCRIPTION
This improves a few things.

- All tests live in `src/` now.
- `Migration#run` now calls into the adapter to actually perform the migration.
- Adding `Migration#prepare` to initialize a migration. This is useful for tests. `Migration#run` will call prepare before it calls into the adapter.
- Removed `Database#getAdapter`, and replaced with a public readonly `adapter` property.
- Added dropTable operation.