### PR TITLE
Bump ES target version

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["esnext"],
-    "target": "es6",
+    "target": "es2017",
     "moduleResolution": "node",
     "module": "commonjs",
     "outDir": "./lib",


### PR DESCRIPTION
This should keep native async/await in the code, which is desired. Fixes #36 