### PR TITLE
Fix query types

### DIFF
--- a/packages/fewer/src/Repository/index.ts
+++ b/packages/fewer/src/Repository/index.ts
@@ -240,7 +240,7 @@ export class Repository<
       this.schemaTable,
       this.selectQuery().where(wheres),
       this.pipes,
-      this.queryType,
+      QueryTypes.MULTIPLE,
     );
   }
 
@@ -263,7 +263,7 @@ export class Repository<
         .where({ id })
         .limit(1),
       this.pipes,
-      this.queryType,
+      QueryTypes.SINGLE,
     );
   }
 


### PR DESCRIPTION
This fixes #41. Find and where should force the query type to the correct value.

Ideally `find` should prevent things like `where` from happening down the chain, but I'm gonna punt figuring that out for now. Alternatively, find / where should nuke the conditions set previously in the chain.