### PR TITLE
Adding password pipe

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 before_script:
-  - apt-get update -qy
-  - apt-get install -y python-dev python-pip
+  - apk add --update python python-dev py-pip
   - yarn
 
 services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,6 @@
 before_script:
+  - apt-get update -qy
+  - apt-get install -y python-dev python-pip
   - yarn
 
 services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 before_script:
-  - apk add --update python python-dev py-pip
+  - apk add --update builds-deps build-base python python-dev py-pip
   - yarn
 
 services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 before_script:
-  - apk add --update builds-deps build-base python python-dev py-pip
+  - apk add --update build-base python python-dev py-pip
   - yarn
 
 services:

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -1,0 +1,11 @@
+# `@fewer/password`
+
+> TODO: description
+
+## Usage
+
+```
+const password = require('@fewer/password');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@fewer/virtuals",
-  "version": "0.1.2",
-  "description": "A pipe to add custom fields and methods to objects returned by the repository",
+  "name": "@fewer/password",
+  "version": "0.1.0",
+  "description": "A pipe that handles hashing passwords",
   "keywords": [
     "fewer",
     "fewer-pipe",
-    "virtuals"
+    "hash",
+    "password"
   ],
   "author": "Jordan Gensler <jgensler@netflix.com>",
   "homepage": "https://github.com/fewer/fewer",
@@ -33,6 +34,10 @@
     "access": "public"
   },
   "devDependencies": {
+    "@types/bcrypt": "^3.0.0",
     "fewer": "^0.1.2"
+  },
+  "dependencies": {
+    "bcrypt": "^3.0.4"
   }
 }

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -8,7 +8,7 @@ type StringPropertyNames<T> = Exclude<
   undefined
 >;
 
-export function password<Instance, Virtual extends string>(
+export function withPassword<Instance, Virtual extends string>(
   virtualField: Virtual,
   hashedField: StringPropertyNames<Instance>,
   saltRounds: number = 12,

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -8,7 +8,7 @@ type StringPropertyNames<T> = Exclude<
   undefined
 >;
 
-export function createPassword<Instance, Virtual extends string>(
+export function password<Instance, Virtual extends string>(
   virtualField: Virtual,
   hashedField: StringPropertyNames<Instance>,
   saltRounds: number = 12,

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -1,0 +1,44 @@
+import { Pipe } from 'fewer';
+import bcrypt from 'bcrypt';
+
+type StringPropertyNames<T> = Exclude<
+  {
+    [K in keyof T]: Exclude<T[K], undefined> extends string ? K : never
+  }[keyof T],
+  undefined
+>;
+
+export function createPassword<Instance, Virtual extends string>(
+  virtualField: Virtual,
+  hashedField: StringPropertyNames<Instance>,
+  saltRounds: number = 12,
+): Pipe<
+  Instance,
+  { [P in Virtual]?: string } & {
+    authenticate(passwordToCheck: string): Promise<boolean>;
+  }
+> {
+  return {
+    async use(instance) {
+      if (instance[virtualField]) {
+        // @ts-ignore: Prevent the index type from causing errors:
+        instance[hashedField] = await bcrypt.hash(
+          instance[virtualField],
+          saltRounds,
+        );
+      }
+    },
+    prepare(instance) {
+      // @ts-ignore: Prevent the index type from causing errors:
+      instance.authenticate = async (password: string) => {
+        if (!instance[hashedField]) {
+          throw new Error(
+            `The hashed field "${hashedField}" was not present, can not authenticate`,
+          );
+        }
+
+        return await bcrypt.compare(password, instance[hashedField] as string);
+      };
+    },
+  };
+}

--- a/packages/password/tsconfig.json
+++ b/packages/password/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+      "composite": true,
+      "outDir": "lib",
+      "rootDir": "src"
+    },
+    "include": ["./src"]
+  }

--- a/packages/validations/package.json
+++ b/packages/validations/package.json
@@ -4,6 +4,7 @@
   "description": "A collection of pipes that handle common model validation use-cases for Fewer",
   "keywords": [
     "fewer",
+    "fewer-pipe",
     "validations"
   ],
   "author": "Jordan Gensler <jgensler@netflix.com>",

--- a/packages/validations/src/confirmation.ts
+++ b/packages/validations/src/confirmation.ts
@@ -1,6 +1,6 @@
 import { Pipe } from 'fewer';
 
-export function confirmation<
+export function withConfirmation<
   Instance,
   FieldName extends keyof Instance,
   ConfirmationFieldName extends string

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -1,2 +1,2 @@
-export { confirmation } from './confirmation';
-export { presence } from './presence';
+export { withConfirmation } from './confirmation';
+export { withPresence } from './presence';

--- a/packages/validations/src/presence.ts
+++ b/packages/validations/src/presence.ts
@@ -1,6 +1,6 @@
 import { Pipe, ValidationError } from 'fewer';
 
-export function presence<Instance, FieldName extends keyof Instance>(
+export function withPresence<Instance, FieldName extends keyof Instance>(
   ...fieldNames: FieldName[]
 ): Pipe<Instance> {
   return {

--- a/packages/virtuals/src/index.ts
+++ b/packages/virtuals/src/index.ts
@@ -1,6 +1,6 @@
 import { Pipe } from 'fewer';
 
-export function createVirtuals<Instance, Extensions>(
+export function virtuals<Instance, Extensions>(
   config: (instance: Instance) => Extensions,
 ): Pipe<Instance, Extensions> {
   return {

--- a/packages/virtuals/src/index.ts
+++ b/packages/virtuals/src/index.ts
@@ -1,6 +1,6 @@
 import { Pipe } from 'fewer';
 
-export function virtuals<Instance, Extensions>(
+export function withVirtuals<Instance, Extensions>(
   config: (instance: Instance) => Extensions,
 ): Pipe<Instance, Extensions> {
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,6 +798,11 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@types/bcrypt@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-3.0.0.tgz#851489a9065a067cb7f3c9cbe4ce9bed8bba0876"
+  integrity sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==
+
 "@types/cosmiconfig@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@types/cosmiconfig/-/cosmiconfig-5.0.3.tgz#880644bb155d4038d3b752159684b777b0a159dd"
@@ -1344,6 +1349,14 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bcrypt@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-3.0.4.tgz#1c881379ddf21bcade56e3172669d27152d90d50"
+  integrity sha512-XqmCym97kT6l+jFEKeFvGuNE9aVEFDGsLMv+tIBTXkJI1sHS0g8s7VQEPJagSMPwWiB5Vpr2kVzVKc/YfwWthA==
+  dependencies:
+    nan "2.12.1"
+    node-pre-gyp "0.12.0"
 
 bin-links@^1.1.2:
   version "1.1.2"
@@ -4839,7 +4852,7 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.9.2:
+nan@2.12.1, nan@^2.9.2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
@@ -4946,6 +4959,22 @@ node-notifier@^5.2.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-pre-gyp@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"


### PR DESCRIPTION
This adds a new `@fewer/password` pipe that can be used to easily manage  password fields in projects.

Example:
```ts
import { createRepository } from 'fewer';
import { password } from '@fewer/password';

export default createRepository(schema.tables.users).pipe(
  password('password', 'password_hash')
);
``` 

I went with named exports because that's what we're doing everywhere. Also renamed the virtuals pipe away from the `create*` naming which I'm going to reserve for the core for now.