### PR TITLE
Update for better multi-db support

### DIFF
--- a/packages/adapter-postgres/src/__integration__/joins.test.ts
+++ b/packages/adapter-postgres/src/__integration__/joins.test.ts
@@ -14,13 +14,13 @@ import { prepare } from './setup';
 type AdapterInstance = InstanceType<typeof Adapter>;
 
 function getSchemaAndRepos(database: Database) {
-  const schema = createSchema()
-    .table(database, 'users', { primaryKey: 'id' }, t => ({
+  const schema = createSchema(database)
+    .table('users', { primaryKey: 'id' }, t => ({
       id: t.bigserial(),
       first_name: t.string(),
       last_name: t.string(),
     }))
-    .table(database, 'posts', { primaryKey: 'id' }, t => ({
+    .table('posts', { primaryKey: 'id' }, t => ({
       id: t.bigserial(),
       title: t.string(),
       user_id: t.bigint(),

--- a/packages/adapter-postgres/src/__integration__/loadAssociation.test.ts
+++ b/packages/adapter-postgres/src/__integration__/loadAssociation.test.ts
@@ -14,13 +14,13 @@ import { prepare } from './setup';
 type AdapterInstance = InstanceType<typeof Adapter>;
 
 function getSchemaAndRepos(database: Database) {
-  const schema = createSchema()
-    .table(database, 'users', { primaryKey: 'id' }, t => ({
+  const schema = createSchema(database)
+    .table('users', { primaryKey: 'id' }, t => ({
       id: t.bigserial(),
       first_name: t.string(),
       last_name: t.string(),
     }))
-    .table(database, 'posts', { primaryKey: 'id' }, t => ({
+    .table('posts', { primaryKey: 'id' }, t => ({
       id: t.bigserial(),
       title: t.string(),
       user_id: t.bigint(),

--- a/packages/adapter-postgres/src/__typo__/basic.test.ts
+++ b/packages/adapter-postgres/src/__typo__/basic.test.ts
@@ -12,13 +12,13 @@ const database = createDatabase({
   adapter: new Adapter({ ...config, database: 'fewer_typo_tests' }),
 });
 
-const schema = createSchema()
-  .table(database, 'users', { primaryKey: 'id' }, t => ({
+const schema = createSchema(database)
+  .table('users', { primaryKey: 'id' }, t => ({
     id: t.bigserial(),
     first_name: t.string(),
     last_name: t.string(),
   }))
-  .table(database, 'posts', { primaryKey: 'id' }, t => ({
+  .table('posts', { primaryKey: 'id' }, t => ({
     id: t.bigserial(),
     title: t.string(),
     user_id: t.bigint(),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,9 +66,9 @@
     "ejs": "^2.6.1",
     "enquirer": "^2.3.0",
     "execa": "^1.0.0",
-    "joi": "^14.3.1",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
+    "optimal": "^2.1.1",
     "prettier": "^1.16.1",
     "ts-node": "^7.0.1"
   },
@@ -78,7 +78,6 @@
     "@types/babel__template": "^7.0.1",
     "@types/cosmiconfig": "^5.0.3",
     "@types/execa": "^0.9.0",
-    "@types/joi": "^14.0.1",
     "@types/lodash": "^4.14.120",
     "@types/mkdirp": "^0.5.2",
     "@types/prettier": "^1.15.2",

--- a/packages/cli/src/commands/generate/database.ts
+++ b/packages/cli/src/commands/generate/database.ts
@@ -10,7 +10,6 @@ export default class GenerateDatabase extends Command {
 
   static examples = [
     '$ fewer generate:database myDatabase',
-    '$ fewer generate:database myDatabase --adapter=mysql',
   ];
 
   static flags = {
@@ -34,6 +33,7 @@ export default class GenerateDatabase extends Command {
     },
   ];
 
+  // TODO: This should scaffold all of the related DB files, and update the fewerrc file.
   async run() {
     const { flags, args } = this.parse(GenerateDatabase);
     const config = await getConfig();

--- a/packages/cli/src/commands/generate/migration.ts
+++ b/packages/cli/src/commands/generate/migration.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import { Command, flags } from '@oclif/command';
+import { Command } from '@oclif/command';
 import commonFlags from '../../commonFlags';
 import getConfig from '../../getConfig';
-import { prompt, createFile, resolve } from '../../utils';
+import { createFile, resolve, getDatabase } from '../../utils';
 
 function pad(num: number) {
   return String(num).padStart(2, '0');
@@ -44,23 +44,17 @@ export default class GenerateMigration extends Command {
         'We did not find any configured databases in your Fewer configuration file.',
       );
     }
-    let [database] = config.databases;
-    if (config.databases.length > 1) {
-      database = await prompt({
-        type: 'select',
-        message: 'Which database is this migration for?',
-        choices: config.databases,
-      });
-    }
+
+    const dbFile = await getDatabase('Which database is this migration for?');
 
     const version = getMigrationVersion();
 
     const migrationFileName = path.join(
-      config.migrations,
+      config.databases[dbFile].migrations,
       `${version}_${args.name}.${config.typescript ? 'ts' : 'js'}`,
     );
 
-    const databaseImportPath = resolve(migrationFileName, database);;
+    const databaseImportPath = resolve(migrationFileName, dbFile);
 
     createFile(
       'migration',

--- a/packages/cli/src/commands/generate/repository.ts
+++ b/packages/cli/src/commands/generate/repository.ts
@@ -11,5 +11,6 @@ export default class GenerateRepository extends Command {
   static args = [];
 
   async run() {
+    throw new Error('Not yet implemented.');
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -24,7 +24,7 @@ export default class Init extends Command {
     const adapter = await prompt({
       type: 'select',
       message: 'Which database will you be connecting to?',
-      choices: ['postgres', 'mysql'],
+      choices: ['postgres'],
     });
 
     const sourceType = await prompt({
@@ -65,7 +65,11 @@ export default class Init extends Command {
     }
 
     cli.action.start('Installing npm dependencies');
-    await installPackages(this.warn, 'fewer', `@fewer/adapter-${adapter.toLowerCase()}`);
+    await installPackages(
+      this.warn,
+      'fewer',
+      `@fewer/adapter-${adapter.toLowerCase()}`,
+    );
     cli.action.stop();
 
     cli.action.start('Creating files');
@@ -84,10 +88,13 @@ export default class Init extends Command {
 
     const fewerConfig: Partial<FewerConfigurationFile> = {
       src,
-      migrations,
-      repositories,
-      schema: path.join(src, `schema.${extension}`),
-      databases: [path.join(src, `database.${extension}`)],
+      databases: {
+        [path.join(src, `database.${extension}`)]: {
+          migrations,
+          repositories,
+          schema: path.join(src, `schema.${extension}`),
+        },
+      },
     };
 
     if (!useTypeScript) {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -80,7 +80,8 @@ export function hasDependency(dep: string) {
 export async function installPackages(warn: Function, ...packages: string[]) {
   const manager = await prompt({
     type: 'select',
-    message: 'Which package manager should be used to install new dependencies?',
+    message:
+      'Which package manager should be used to install new dependencies?',
     choices: ['npm', 'yarn', 'skip dependencies'],
   });
 
@@ -89,7 +90,11 @@ export async function installPackages(warn: Function, ...packages: string[]) {
   } else if (manager === 'yarn') {
     await execa('yarn', ['add', ...packages]);
   } else {
-    warn(`The following dependencies are required to run, but were not installed: ${packages.join(', ')}`);
+    warn(
+      `The following dependencies are required to run, but were not installed: ${packages.join(
+        ', ',
+      )}`,
+    );
   }
 }
 
@@ -150,17 +155,38 @@ export async function createFile(
   );
 }
 
-export async function getMigrations() {
+export async function getMigrations(dbFile: string) {
   const config = await getConfig();
 
   // TODO: Store project root somewhere (read-pkg-up?) so that I don't need to do cwd garbage:
   const migrationFiles = await readdirAsync(
-    path.resolve(cwd, config.migrations),
+    path.resolve(cwd, config.databases[dbFile].migrations),
   );
 
   return sortBy(
     migrationFiles.filter(filename => !filename.startsWith('.')),
-  ).map(filename => path.join(cwd, config.migrations, filename));
+  ).map(filename =>
+    path.join(cwd, config.databases[dbFile].migrations, filename),
+  );
+}
+
+export async function getDatabase(
+  message: string = 'Which database would you like to use?',
+) {
+  const config = await getConfig();
+
+  const databases = Object.keys(config.databases);
+
+  let dbFile = databases[0];
+  if (databases.length > 1) {
+    dbFile = await prompt({
+      type: 'select',
+      message: message,
+      choices: databases,
+    });
+  }
+
+  return dbFile;
 }
 
 export function resolve(from: string, to: string) {

--- a/packages/cli/templates/schema.ejs
+++ b/packages/cli/templates/schema.ejs
@@ -3,15 +3,15 @@
 // Generally this file should not be modified manually, but instead should be
 // re-generated from the state of the Database.
 // You can use the fewer CLI to re-generate this by running:
-//   * `fewer db:schema` - Generate the schema using the current state of the database.
-//   * `fewer db:schema --offline` - Generates the schema offline by running through the migrations.
+//   * `fewer db:schema` - Generates the schema offline by running through the migrations.
+//   * `fewer db:schema --online` - Generates the schema using the current state of the database.
 
 import { createSchema } from 'fewer';
-<%- databases.map(db => `import ${db.importName} from '${db.ident}';`).join('\n') %>
+import database from '<%- dbImport %>';
 
-export default createSchema()
+export default createSchema(database<%= version ? `, ${version}` : '' %>)
     <%_ tables.forEach((table) => { _%>
-        .table(<%= table.database.importName %>, <%- JSON.stringify(table.name) %>, <%- JSON.stringify(table.options) %>, (t) => ({
+        .table(<%- JSON.stringify(table.name) %>, <%- JSON.stringify(table.options) %>, (t) => ({
             <%_ table.columns.forEach((col) => { _%>
             <%- JSON.stringify(col.name) %>: t.<%- col.method %>(
                 <%-

--- a/packages/fewer/src/Repository/__tests__/queryBuilding.test.ts
+++ b/packages/fewer/src/Repository/__tests__/queryBuilding.test.ts
@@ -18,13 +18,13 @@ interface Post {
   userId: number;
 }
 
-const schema = createSchema()
-  .table(database, 'users', { primaryKey: 'id' }, t => ({
+const schema = createSchema(database)
+  .table('users', { primaryKey: 'id' }, t => ({
     id: t.number(),
     firstName: t.string(),
     lastName: t.string(),
   }))
-  .table(database, 'posts', { primaryKey: 'id' }, t => ({
+  .table('posts', { primaryKey: 'id' }, t => ({
     id: t.number(),
     title: t.string(),
     subtitle: t.maybeString(),

--- a/packages/fewer/src/__typeval__/fail/associations.ts
+++ b/packages/fewer/src/__typeval__/fail/associations.ts
@@ -6,12 +6,12 @@ import {
 } from '../../';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema()
-  .table(database, 'users', { primaryKey: 'id' }, t => ({
+const schema = createSchema(database)
+  .table('users', { primaryKey: 'id' }, t => ({
     firstName: t.string(),
     lastName: t.string(),
   }))
-  .table(database, 'posts', { primaryKey: 'id' }, t => ({
+  .table('posts', { primaryKey: 'id' }, t => ({
     title: t.string(),
     subtitle: t.maybeString(),
     userId: t.number(),

--- a/packages/fewer/src/__typeval__/fail/brokenJoins.ts
+++ b/packages/fewer/src/__typeval__/fail/brokenJoins.ts
@@ -6,12 +6,12 @@ import {
 } from '../../';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema()
-  .table(database, 'users', { primaryKey: 'id' }, t => ({
+const schema = createSchema(database)
+  .table('users', { primaryKey: 'id' }, t => ({
     firstName: t.string(),
     lastName: t.string(),
   }))
-  .table(database, 'posts', { primaryKey: 'id' }, t => ({
+  .table('posts', { primaryKey: 'id' }, t => ({
     title: t.string(),
     subtitle: t.maybeString(),
     userId: t.number(),

--- a/packages/fewer/src/__typeval__/fail/mismatch-types.errors.json
+++ b/packages/fewer/src/__typeval__/fail/mismatch-types.errors.json
@@ -2,11 +2,11 @@
     {
         "location": {
             "start": {
-                "line": 7,
+                "line": 8,
                 "column": 23
             },
             "end": {
-                "line": 7,
+                "line": 8,
                 "column": 37
             }
         },

--- a/packages/fewer/src/__typeval__/fail/mismatch-types.ts
+++ b/packages/fewer/src/__typeval__/fail/mismatch-types.ts
@@ -1,7 +1,8 @@
 import * as typeval from '@fewer/typeval';
 import { createSchema } from '../../';
+import { database } from '../../__tests__/mocks';
 
-const schema = createSchema(20080906171750);
+const schema = createSchema(database, 20080906171750);
 
 // Test individual properties:
 typeval.acceptsString(schema.version);

--- a/packages/fewer/src/__typeval__/fail/pluck-missing.ts
+++ b/packages/fewer/src/__typeval__/fail/pluck-missing.ts
@@ -6,14 +6,14 @@ import {
 } from '../../';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema()
-  .table(database, 'users', { primaryKey: 'id' }, t => ({
+const schema = createSchema(database)
+  .table('users', { primaryKey: 'id' }, t => ({
     firstName: t.string(),
     middleName: t.string(),
     lastName: t.string(),
     birthday: t.maybe<Date>(),
   }))
-  .table(database, 'posts', { primaryKey: 'id' }, t => ({
+  .table('posts', { primaryKey: 'id' }, t => ({
     title: t.string(),
     subtitle: t.string(),
     content: t.string(),

--- a/packages/fewer/src/__typeval__/pass/associations.ts
+++ b/packages/fewer/src/__typeval__/pass/associations.ts
@@ -7,12 +7,12 @@ import {
 } from '../../';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema()
-  .table(database, 'users', { primaryKey: 'id' }, t => ({
+const schema = createSchema(database)
+  .table('users', { primaryKey: 'id' }, t => ({
     firstName: t.string(),
     lastName: t.string(),
   }))
-  .table(database, 'posts', { primaryKey: 'id' }, t => ({
+  .table('posts', { primaryKey: 'id' }, t => ({
     title: t.string(),
     subtitle: t.maybeString(),
     userId: t.number(),

--- a/packages/fewer/src/__typeval__/pass/repository-pluck.ts
+++ b/packages/fewer/src/__typeval__/pass/repository-pluck.ts
@@ -2,8 +2,7 @@ import * as typeval from '@fewer/typeval';
 import { createRepository, createSchema } from '../../';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema().table(
-  database,
+const schema = createSchema(database).table(
   'users',
   { primaryKey: 'id' },
   t => ({

--- a/packages/fewer/src/__typeval__/pass/repository-symbol-accessors.ts
+++ b/packages/fewer/src/__typeval__/pass/repository-symbol-accessors.ts
@@ -2,8 +2,7 @@ import * as typeval from '@fewer/typeval';
 import { createRepository, ValidationError, createSchema } from '../../';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema().table(
-  database,
+const schema = createSchema(database).table(
   'users',
   { primaryKey: 'id' },
   t => ({

--- a/packages/fewer/src/__typeval__/pass/schema-types-basic.ts
+++ b/packages/fewer/src/__typeval__/pass/schema-types-basic.ts
@@ -3,8 +3,7 @@ import { createSchema } from '../../';
 import { INTERNAL_TYPES } from '../../types';
 import { database } from '../../__tests__/mocks';
 
-const schema = createSchema().table(
-  database,
+const schema = createSchema(database).table(
   'users',
   { primaryKey: 'id' },
   t => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,13 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.1.tgz#8f4ffd45f779e6132780835ffa7a215fa0b2d181"
   integrity sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==
 
+"@babel/runtime@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -5191,6 +5198,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+optimal@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/optimal/-/optimal-2.1.1.tgz#520e0c7ac6fb92ffe72db67971cc35b7f7826e11"
+  integrity sha512-M2J0hZTenzevjPErXW4YRefQt1erPGW6Ewsb8/5sGL9SAXDfR+zOw8A9SO1085Qt2e5bGtWvXOi6sN+WZNhzZw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -5895,6 +5909,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regex-cache@^0.4.2:
   version "0.4.4"


### PR DESCRIPTION
This fixes #65. Our multi-db support should now be pretty solid. The fewerrc file now has each database completely isolated. We expect each DB to have its own schema, its own migrations, repositories (although the folder for these could reasonably be shared).